### PR TITLE
[minor]refactor: NativeVersion and RuntimeVersion

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -4,7 +4,9 @@
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
+use sp_version::NativeVersion;
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+use sp_version::RuntimeVersion;
 
 use sp_std::prelude::*;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -19,9 +21,6 @@ use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use pallet_grandpa::fg_primitives;
-use sp_version::RuntimeVersion;
-#[cfg(feature = "std")]
-use sp_version::NativeVersion;
 
 // A few exports that help ease life for downstream crates.
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
This is a minor refactor for NativeVersion and RuntimeVersion positioning, to clean up unnecessary reused codes.