### PR TITLE
Feat/update order failed status

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### JIRA Link
+URL to your task/ticket number in JIRA (if applicable)
+If there's no JIRA ticket number, describe why in description below.
+
+### Changelog / Description
+The description of your task or what is changed.
+e.g: Update substrate config, new feature / bugfix, etc. 

--- a/pallets/genetic-testing/src/lib.rs
+++ b/pallets/genetic-testing/src/lib.rs
@@ -18,7 +18,7 @@ pub use frame_support::traits::Randomness;
 pub use sp_std::prelude::*;
 pub use sp_std::fmt::Debug;
 pub use traits_genetic_testing::{GeneticTestingProvider, DnaSampleTracking};
-pub use traits_order::{OrderEventEmitter};
+pub use traits_order::{OrderEventEmitter, OrderStatusUpdater};
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -28,7 +28,7 @@ pub mod pallet {
     pub trait Config: frame_system::Config + pallet_timestamp::Config {
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
         type RandomnessSource: Randomness<Self::Hash>;
-        type Orders: OrderEventEmitter<Self>;
+        type Orders: OrderEventEmitter<Self> + OrderStatusUpdater<Self>;
     }
 
     // ----- This is template code, every pallet needs this ---
@@ -454,6 +454,7 @@ impl<T: Config> GeneticTestingInterface<T> for Pallet<T> {
         dna_sample.updated_at = now;
         DnaSamples::<T>::insert(tracking_id, &dna_sample);
         T::Orders::emit_event_order_failed(&dna_sample.order_id);
+        T::Orders::update_status_failed(&dna_sample.order_id);
 
         Ok(dna_sample)
     }

--- a/pallets/orders/src/lib.rs
+++ b/pallets/orders/src/lib.rs
@@ -14,7 +14,7 @@ use traits_services::{
     types::{ Price }
 };
 use traits_genetic_testing::{GeneticTestingProvider, DnaSampleTracking};
-use traits_order::{OrderEventEmitter};
+use traits_order::{OrderEventEmitter, OrderStatusUpdater};
 
 
 #[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq)]
@@ -24,6 +24,7 @@ pub enum OrderStatus {
     Success,
     Refunded,
     Cancelled,
+    Failed,
 }
 impl Default for OrderStatus {
     fn default() -> Self { OrderStatus::Unpaid }
@@ -528,6 +529,17 @@ impl<T: Config> OrderEventEmitter<T> for Pallet<T> {
         match Self::order_by_id(order_id) {
             None => Self::deposit_event(Event::OrderNotFound),
             Some(order) => Self::deposit_event(Event::OrderFailed(order))
+        }
+    }
+}
+
+impl<T: Config> OrderStatusUpdater<T> for Pallet<T> {
+    fn update_status_failed(order_id: &HashOf<T>) -> () {
+        match Self::order_by_id(order_id) {
+            None => Self::deposit_event(Event::OrderNotFound),
+            Some(order) => {
+                Self::update_order_status(&order.id, OrderStatus::Failed);
+            },
         }
     }
 }

--- a/traits/order/src/lib.rs
+++ b/traits/order/src/lib.rs
@@ -5,3 +5,7 @@ use frame_system::Config;
 pub trait OrderEventEmitter<T: Config> {
     fn emit_event_order_failed(order_id: &T::Hash) -> ();
 }
+
+pub trait OrderStatusUpdater<T: Config> {
+    fn update_status_failed(order_id: &T::Hash) -> ();
+}

--- a/types.json
+++ b/types.json
@@ -74,7 +74,8 @@
       "Paid",
       "Success",
       "Refunded",
-      "Cancelled"
+      "Cancelled",
+      "Failed"
     ]
   },
   "MomentOf": "Moment",
@@ -97,9 +98,14 @@
   "DnaSampleStatus": {
     "_enum": [
       "Sending",
-      "Received",
+      "Registered",
+      "Arrived",
       "Rejected",
-      "Processing",
+      "Prepared",
+      "Extracted",
+      "Genotyped",
+      "Reviewed",
+      "Computed",
       "Success",
       "Failed"
     ]


### PR DESCRIPTION
### JIRA Link
https://blocksphere2020.atlassian.net/browse/DBIO-343?atlOrigin=eyJpIjoiMmQ3NDE0ZDg5YTZhNDZiMGI5YmMzNjVjYTY5MDYyZDEiLCJwIjoiaiJ9

### Changelog / Description
Substrate | Update order jadi failed ketika dna sample rejected (Event udah fired)

- Add enum OrderStatus::Failed
- Create trait OrderStatusUpdater
- implement OrderStatusUpdater.update_order_failed_status
- Update types.json

BREAKING CHANGE: new OrderStatus enum "Failed" is added to types.json.
Other projects (FE, BE, Faucet) that communicate with debio-node need to
update their types.json