### PR TITLE
Dbio 473

### DIFF
--- a/pallets/genetic-testing/src/interface.rs
+++ b/pallets/genetic-testing/src/interface.rs
@@ -2,7 +2,7 @@ use sp_std::prelude::*;
 
 pub trait GeneticTestingInterface<T: frame_system::Config> {
     type DnaSample;
-    type DnaSampleStatus; // ----- Update -----
+    type DnaSampleStatus;
     type DnaTestResult;
     type DnaTestResultSubmission;
     type Error;

--- a/pallets/genetic-testing/src/lib.rs
+++ b/pallets/genetic-testing/src/lib.rs
@@ -53,18 +53,16 @@ pub mod pallet {
         DnaSampleSuccess(DnaSampleOf<T>),
         /// Failed
         DnaSampleFailed(DnaSampleOf<T>),
-        /// Prepared
-        DnaSamplePrepared(DnaSampleOf<T>),
-        /// Extracted
-        DnaSampleExtracted(DnaSampleOf<T>),
-        /// Genotyped
-        DnaSampleGenotyped(DnaSampleOf<T>),
+        /// QualityControlled
+        DnaSampleQualityControlled(DnaSampleOf<T>),
+        /// GenotypedSequenced
+        DnaSampleGenotypedSequenced(DnaSampleOf<T>),
         /// Reviewed
         DnaSampleReviewed(DnaSampleOf<T>),
         /// Computed
         DnaSampleComputed(DnaSampleOf<T>),
-        /// Dna Sample Processed
-        DnaSampleProcessed(DnaTestResultOf<T>),
+        /// ResultReady
+        DnaSampleResultReady(DnaSampleOf<T>),
         /// Dna Test Result Submitted
         DnaTestResultSubmitted(DnaTestResultOf<T>),
     }
@@ -165,16 +163,12 @@ pub mod pallet {
                 Ok(dna_sample) => {
 
                     match status {
-                        DnaSampleStatus::Registered => (),
-                        DnaSampleStatus::Arrived => (),
-                        DnaSampleStatus::Rejected => (),
-                        DnaSampleStatus::Success => (),
-                        DnaSampleStatus::Failed => (),
-                        DnaSampleStatus::Prepared => Self::deposit_event(Event::<T>::DnaSamplePrepared(dna_sample.clone())),
-                        DnaSampleStatus::Extracted => Self::deposit_event(Event::<T>::DnaSampleExtracted(dna_sample.clone())),
-                        DnaSampleStatus::Genotyped => Self::deposit_event(Event::<T>::DnaSampleGenotyped(dna_sample.clone())),
+                        DnaSampleStatus::QualityControlled => Self::deposit_event(Event::<T>::DnaSampleQualityControlled(dna_sample.clone())),
+                        DnaSampleStatus::GenotypedSequenced => Self::deposit_event(Event::<T>::DnaSampleGenotypedSequenced(dna_sample.clone())),
                         DnaSampleStatus::Reviewed => Self::deposit_event(Event::<T>::DnaSampleReviewed(dna_sample.clone())),
                         DnaSampleStatus::Computed => Self::deposit_event(Event::<T>::DnaSampleComputed(dna_sample.clone())),
+                        DnaSampleStatus::ResultReady => Self::deposit_event(Event::<T>::DnaSampleResultReady(dna_sample.clone())),
+                        _ => (),
                     }
 
                     Ok(().into())
@@ -189,7 +183,7 @@ pub mod pallet {
 
             match <Self as GeneticTestingInterface<T>>::submit_test_result(&who, &tracking_id, &submission) {
                 Ok(dna_test_result) => {
-                    Self::deposit_event(Event::<T>::DnaSampleProcessed(dna_test_result.clone()));
+                    Self::deposit_event(Event::<T>::DnaTestResultSubmitted(dna_test_result.clone()));
                     Ok(().into())
                 },
                 Err(error) => Err(error)?
@@ -219,11 +213,11 @@ pub enum DnaSampleStatus {
     Rejected,
     Success,
     Failed,
-    Prepared,
-    Extracted,
-    Genotyped,
+    QualityControlled,
+    GenotypedSequenced,
     Reviewed,
-    Computed
+    Computed,
+    ResultReady,
 }
 impl Default for DnaSampleStatus {
     fn default() -> Self {

--- a/pallets/orders/src/lib.rs
+++ b/pallets/orders/src/lib.rs
@@ -21,7 +21,7 @@ use traits_order::{OrderEventEmitter, OrderStatusUpdater};
 pub enum OrderStatus {
     Unpaid,
     Paid,
-    Success,
+    Fulfilled,
     Refunded,
     Cancelled,
     Failed,
@@ -182,9 +182,9 @@ pub mod pallet {
         /// Order paid
         /// parameters, [Order]
         OrderPaid(OrderOf<T>),
-        /// Order Success
+        /// Order Fulfilled
         /// parameters, [Order]
-        OrderSuccess(OrderOf<T>),
+        OrderFulfilled(OrderOf<T>),
         /// Order Refunded
         /// parameters, [Order]
         OrderRefunded(OrderOf<T>),
@@ -275,7 +275,7 @@ pub mod pallet {
 
             match <Self as OrderInterface<T>>::fulfill_order(&who, &order_id) {
                 Ok(order) => {
-                    Self::deposit_event(Event::<T>::OrderSuccess(order.clone()));
+                    Self::deposit_event(Event::<T>::OrderFulfilled(order.clone()));
                     Ok(().into())
                 },
                 Err(error) => Err(error)?
@@ -397,7 +397,7 @@ impl<T: Config> OrderInterface<T> for Pallet<T> {
             return Err(Error::<T>::DnaSampleNotSuccessfullyProcessed);
         }
 
-        let order = Self::update_order_status(order_id, OrderStatus::Success);
+        let order = Self::update_order_status(order_id, OrderStatus::Fulfilled);
 
         Ok(order.unwrap())
     }

--- a/traits/genetic-testing/src/lib.rs
+++ b/traits/genetic-testing/src/lib.rs
@@ -17,11 +17,3 @@ pub trait GeneticTestingProvider<T: frame_system::Config> {
     fn dna_sample_by_tracking_id(tracking_id: &Vec<u8>) -> Option<Self::DnaSample>;
     fn delete_dna_sample(tracking_id: &Vec<u8>) -> Result<Self::DnaSample, Self::Error>;
 }
-
-pub trait DnaSampleStatus {
-    fn prepared(&self) -> &Vec<u8>;
-    fn extracted(&self) -> &Vec<u8>;
-    fn genotyped(&self) -> &Vec<u8>;
-    fn reviewed(&self) -> &Vec<u8>;
-    fn computed(&self) -> &Vec<u8>;
-}

--- a/types.json
+++ b/types.json
@@ -94,7 +94,7 @@
     "_enum": [
       "Unpaid",
       "Paid",
-      "Success",
+      "FulFilled",
       "Refunded",
       "Cancelled",
       "Failed"

--- a/types.json
+++ b/types.json
@@ -119,17 +119,16 @@
   "OrderIdsOf": "Vec<H256>",
   "DnaSampleStatus": {
     "_enum": [
-      "Sending",
       "Registered",
       "Arrived",
       "Rejected",
-      "Prepared",
-      "Extracted",
-      "Genotyped",
+      "Success",
+      "Failed",
+      "QualityControlled",
+      "GenotypedSequenced",
       "Reviewed",
       "Computed",
-      "Success",
-      "Failed"
+      "ResultReady"
     ]
   },
   "DnaSampleTrackingId": "Text",


### PR DESCRIPTION
### JIRA Link
- [Substrate] Change wording order success to order fulfilled
https://blocksphere2020.atlassian.net/browse/DBIO-447?atlOrigin=eyJpIjoiMjgxN2E2NTA4NzgyNDMyMGE0NDAwOTBhODg2N2Y5ZWUiLCJwIjoiaiJ9

### Changelog / Description
- change `order_success` to `order_fulfilled`

- [Substrate] Change and adapt status name based on Confluence
https://blocksphere2020.atlassian.net/browse/DBIO-473?atlOrigin=eyJpIjoiNTU3OWFkNWQ0NTJhNGZkYmJhYTkzZjM0NWFhY2JjNjAiLCJwIjoiaiJ9

### Changelog / Description
- Changed enum Event 'DnaSamplePrepared` and `DnaSampleExtracted` to `DnaSampleQualityControlled`
- Changed enum Event `DnaSampleGenotyped` to `DnaSampleGenotyoedSequenced`
- Added enum Event `DnaSampleResultReady`
- Changed fn `process_dna_sample` accordingly

### BREAKING CHANGE:
- Changed `types.json` so other projects (FE, BE, Faucet, etc) that communicate with `debio-node` need to update their types.json