### PR TITLE
Substrate add new fields in doctor certification and hospital certification pallet

### DIFF
--- a/pallets/doctor-certifications/src/lib.rs
+++ b/pallets/doctor-certifications/src/lib.rs
@@ -22,6 +22,7 @@ pub struct DoctorCertificationInfo {
     month: Vec<u8>,
     year: Vec<u8>,
     description: Vec<u8>,
+    supporting_document: Option<Vec<u8>>,
 }
 
 #[derive(Encode, Decode, Clone, Default, RuntimeDebug, PartialEq, Eq)]

--- a/pallets/hospital-certifications/src/lib.rs
+++ b/pallets/hospital-certifications/src/lib.rs
@@ -22,6 +22,7 @@ pub struct HospitalCertificationInfo {
     month: Vec<u8>,
     year: Vec<u8>,
     description: Vec<u8>,
+    supporting_document: Option<Vec<u8>>,
 }
 
 #[derive(Encode, Decode, Clone, Default, RuntimeDebug, PartialEq, Eq)]

--- a/types.json
+++ b/types.json
@@ -214,7 +214,8 @@
     "issuer": "Text",
     "month": "Text",
     "year": "Text",
-    "description": "Text"
+    "description": "Text",
+    "supporting_document": "Option<Text>"
   },
   "DoctorCertification": {
     "id": "H256",
@@ -246,7 +247,8 @@
     "issuer": "Text",
     "month": "Text",
     "year": "Text",
-    "description": "Text"
+    "description": "Text",
+    "supporting_document": "Option<Text>"
   },
   "HospitalCertification": {
     "id": "H256",


### PR DESCRIPTION
### JIRA Link
https://blocksphere2020.atlassian.net/browse/DBIO-511?atlOrigin=eyJpIjoiMWE5MzQ1ZGMzMjM3NGE1ZThmYmEzN2Q1N2IyMGY2YTAiLCJwIjoiaiJ9

https://blocksphere2020.atlassian.net/browse/DBIO-512?atlOrigin=eyJpIjoiMmM0NDhlNGZiZjA2NGJiYTlmMzBhNmVhNzA5NTRhYTciLCJwIjoiaiJ9

### Changelog / Description
Substrate | Add supporting document field to Hospitals certifications pallet
Substrate | Add supporting document field to Doctor certifications pallet

- Add `supporting_document` field in doctor certifications
- Add `supporting_document` field in hospital certifications
- Update `types.json`

#### BREAKING CHANGE: 
- New `CurrencyType` and `DurationType` enum added to `types.json`, other projects (FE, BE, Faucet) that communicate with `debio-node` need to update their `types.json`.