### PR TITLE
Feat: Substrate update people who stake + notification

### DIFF
--- a/pallets/genetic-testing/src/interface.rs
+++ b/pallets/genetic-testing/src/interface.rs
@@ -6,6 +6,8 @@ pub trait GeneticTestingInterface<T: frame_system::Config> {
     type DnaTestResult;
     type DnaTestResultSubmission;
     type Error;
+    type StakedData;
+    type DataHash;
 
     fn register_dna_sample(lab_id: &T::AccountId, owner_id: &T::AccountId, order_id: &T::Hash) -> Result<Self::DnaSample, Self::Error>;
     fn receive_dna_sample(lab_id: &T::AccountId, tracking_id: &Vec<u8>) -> Result<Self::DnaSample, Self::Error>;
@@ -34,4 +36,6 @@ pub trait GeneticTestingInterface<T: frame_system::Config> {
     fn dna_test_results_by_owner_id(owner_id: &T::AccountId) -> Option<Vec<Vec<u8>>>;
     // Return dna sample tracking ids
     fn dna_test_results_by_lab_id(lab_id: &T::AccountId) -> Option<Vec<Vec<u8>>>;
+    // Submit data staking details
+    fn submit_data_staking_details(data_staker: &T::AccountId, data_hash: &Self::DataHash) -> Result<Self::StakedData, Self::Error>;
 }

--- a/pallets/genetic-testing/src/interface.rs
+++ b/pallets/genetic-testing/src/interface.rs
@@ -7,7 +7,6 @@ pub trait GeneticTestingInterface<T: frame_system::Config> {
     type DnaTestResultSubmission;
     type Error;
     type StakedData;
-    type DataHash;
 
     fn register_dna_sample(lab_id: &T::AccountId, owner_id: &T::AccountId, order_id: &T::Hash) -> Result<Self::DnaSample, Self::Error>;
     fn receive_dna_sample(lab_id: &T::AccountId, tracking_id: &Vec<u8>) -> Result<Self::DnaSample, Self::Error>;
@@ -37,5 +36,5 @@ pub trait GeneticTestingInterface<T: frame_system::Config> {
     // Return dna sample tracking ids
     fn dna_test_results_by_lab_id(lab_id: &T::AccountId) -> Option<Vec<Vec<u8>>>;
     // Submit data staking details
-    fn submit_data_staking_details(data_staker: &T::AccountId, data_hash: &Self::DataHash) -> Result<Self::StakedData, Self::Error>;
+    fn submit_data_staking_details(data_staker: &T::AccountId, data_hash: &T::Hash) -> Result<Self::StakedData, Self::Error>;
 }

--- a/pallets/genetic-testing/src/lib.rs
+++ b/pallets/genetic-testing/src/lib.rs
@@ -213,7 +213,7 @@ pub mod pallet {
         }
 
         #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
-        pub fn submit_data_staking_details(origin: OriginFor<T>, data_staker: T::AccountId, data_hash: DataHash<T>) -> DispatchResultWithPostInfo {
+        pub fn submit_data_staking_details(origin: OriginFor<T>, data_hash: T::Hash) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
 
             match <Self as GeneticTestingInterface<T>>::submit_data_staking_details(&who, &data_hash) {
@@ -348,7 +348,6 @@ impl<T: Config> GeneticTestingInterface<T> for Pallet<T> {
     type DnaTestResultSubmission = DnaTestResultSubmission;
     type Error = Error<T>;
     type StakedData = HashOf<T>;
-    type DataHash = HashOf<T>;
 
     fn register_dna_sample(lab_id: &T::AccountId, owner_id: &T::AccountId, order_id: &HashOf<T>) -> Result<Self::DnaSample, Self::Error> {
         let seed = Self::generate_random_seed(lab_id, owner_id);
@@ -565,7 +564,7 @@ impl<T: Config> GeneticTestingInterface<T> for Pallet<T> {
     // Submit data staking details
     fn submit_data_staking_details(
         data_staker: &T::AccountId, 
-        data_hash: &Self::DataHash
+        data_hash: &T::Hash
     ) 
         -> Result<Self::StakedData, Self::Error>
     {

--- a/pallets/genetic-testing/src/lib.rs
+++ b/pallets/genetic-testing/src/lib.rs
@@ -66,7 +66,7 @@ pub mod pallet {
         /// Dna Test Result Submitted
         DnaTestResultSubmitted(DnaTestResultOf<T>),
         /// Submit Data Staking Details
-        DataStaked(HashOf<T>)
+        DataStaked(AccountIdOf<T>, HashOf<T>),
     }
 
     #[pallet::error]
@@ -218,7 +218,7 @@ pub mod pallet {
 
             match <Self as GeneticTestingInterface<T>>::submit_data_staking_details(&who, &data_hash) {
                 Ok(data_staker) => {
-                    Self::deposit_event(Event::<T>::DataStaked(data_staker.clone()));
+                    Self::deposit_event(Event::<T>::DataStaked(who.clone(), data_hash.clone()));
                     Ok(().into())
                 },
                 Err(error) => Err(error)?
@@ -569,15 +569,9 @@ impl<T: Config> GeneticTestingInterface<T> for Pallet<T> {
         -> Result<Self::StakedData, Self::Error>
     {
         let data_staker = data_staker.clone();
-        if data_staker != data_staker.clone() { 
-            return Err(Error::<T>::DataStakerNotFound);
-        }
-
+        
         let data_hash = data_hash.clone();
-        if data_hash != data_hash.clone() { 
-            return Err(Error::<T>::DataHashNotFound);
-        }
-
+        
         StakedDataByAccountId::<T>::insert(data_staker, data_hash);
 
         Ok(data_hash)


### PR DESCRIPTION
## JIRA link
https://blocksphere2020.atlassian.net/browse/DBIO-545?atlOrigin=eyJpIjoiYmVlMTdhMjlkMjEyNDBiMGE3ZGM2N2M5ZjZkMjJjZjYiLCJwIjoiaiJ9

## Changelog / Description
Update substrate on list of people who stake + notification

- Add Stakers trait in user-profile pallet
- Add `stakers by account id getter` and `setter` fn in user-profile pallet
- Add `StakersByAccountId` storage in user-profile pallet