### PR TITLE
Update to barnacle v0.9.12-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-appchain"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#812286cf840973fd0c87157bbe800f2c03fdc7b5"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#03a97c49019a019a486ece175a54de23f91a40f8"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-lpos"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#812286cf840973fd0c87157bbe800f2c03fdc7b5"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#03a97c49019a019a486ece175a54de23f91a40f8"
 dependencies = [
  "borsh",
  "frame-support",
@@ -4522,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-support"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#812286cf840973fd0c87157bbe800f2c03fdc7b5"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#03a97c49019a019a486ece175a54de23f91a40f8"
 dependencies = [
  "borsh",
  "frame-support",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-upward-messages"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#812286cf840973fd0c87157bbe800f2c03fdc7b5"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#03a97c49019a019a486ece175a54de23f91a40f8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8240,7 +8240,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -144,7 +144,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 106,
+	spec_version: 107,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Should be merged after #219 
This update fixes a validator node submitting incorrect request when there are multiple pairs of session keys locally.