### PR TITLE
Update to barnacle v0.9.12-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-appchain"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#03a97c49019a019a486ece175a54de23f91a40f8"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#29b52d416d34e1585ced096a44ce31a172365b07"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -4595,9 +4595,10 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-lpos"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#03a97c49019a019a486ece175a54de23f91a40f8"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#29b52d416d34e1585ced096a44ce31a172365b07"
 dependencies = [
  "borsh",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "hex",
@@ -4616,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-support"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#03a97c49019a019a486ece175a54de23f91a40f8"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#29b52d416d34e1585ced096a44ce31a172365b07"
 dependencies = [
  "borsh",
  "frame-support",
@@ -4629,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-upward-messages"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#03a97c49019a019a486ece175a54de23f91a40f8"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#29b52d416d34e1585ced096a44ce31a172365b07"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8356,7 +8357,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -144,7 +144,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 108,
+	spec_version: 109,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -599,7 +599,7 @@ impl pallet_octopus_appchain::Config for Runtime {
 parameter_types! {
 	pub const SessionsPerEra: sp_staking::SessionIndex = 6;
 	pub const BondingDuration: pallet_octopus_lpos::EraIndex = 24 * 28;
-	pub const BlocksPerEra: u32 = EPOCH_DURATION_IN_BLOCKS * 6 / (SECS_PER_BLOCK as u32);
+	pub const BlocksPerEra: u32 = EPOCH_DURATION_IN_BLOCKS * 6;
 }
 
 impl pallet_octopus_lpos::Config for Runtime {


### PR DESCRIPTION
- When a validator produces less than 80% of the expected blocks, no reward is distributed.
- Saves the result of the cross-chain messages

please update the package version of runtime (https://github.com/debionetwork/debio-node/blob/main/runtime/Cargo.toml#L8) before merging.