### PR TITLE
Update octopus-pallets and bump spec_version to 119

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-appchain"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#5c9dbf4ab617f2b0655ab0a9a94f7fca9578c975"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#51ed694034b57c73ebb177502470df602140ddad"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-lpos"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#5c9dbf4ab617f2b0655ab0a9a94f7fca9578c975"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#51ed694034b57c73ebb177502470df602140ddad"
 dependencies = [
  "borsh",
  "frame-benchmarking",
@@ -5002,7 +5002,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-support"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#5c9dbf4ab617f2b0655ab0a9a94f7fca9578c975"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#51ed694034b57c73ebb177502470df602140ddad"
 dependencies = [
  "borsh",
  "frame-support",
@@ -5015,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-upward-messages"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#5c9dbf4ab617f2b0655ab0a9a94f7fca9578c975"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#51ed694034b57c73ebb177502470df602140ddad"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8850,7 +8850,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -147,7 +147,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 118,
+	spec_version: 119,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Hi @irmannmal, this PR updates octopus pallets to the latest version.
I also bumped the spec_version to 119 and am preparing for a runtime upgrade on testnet.