### PR TITLE
feat: move 5% fees to treasury wallet

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -559,7 +559,7 @@ fn genesis(
 		},
 		genetic_analysis_orders: GeneticAnalysisOrdersConfig {
 			escrow_key: api_admin_key.clone(),
-			treasury_key: treasury_key.clone(),
+			treasury_key,
 		},
 		service_request: ServiceRequestConfig { admin_key: api_admin_key.clone() },
 		user_profile: UserProfileConfig { admin_key: api_admin_key },

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -218,6 +218,9 @@ pub fn staging_testnet_config() -> Result<ChainSpec, String> {
 				// API admin account
 				// 5ELYNFhFz9tauMxfjgTGhd6sRbnndddEXqh3UxWsPi6Rjajg
 				hex!["648c728f7fcf0ae26a44410cf0ba4ea15b27b3169a4f809a14097680b8d0bc53"].into(),
+				// Treasury account
+				// 5ELYNFhFz9tauMxfjgTGhd6sRbnndddEXqh3UxWsPi6Rjajg
+				hex!["648c728f7fcf0ae26a44410cf0ba4ea15b27b3169a4f809a14097680b8d0bc53"].into(),
 			)
 		},
 		// Bootnodes
@@ -338,6 +341,9 @@ pub fn development_testnet_config() -> Result<ChainSpec, String> {
 				// API admin account
 				// C8KpmHUFT7HJbNLv74cXrtT1w9LF1W3WduN8nVGQUySSJTF
 				hex!["02c2cffef38fbf56b32d6a49eeeecc0e3345a1e0549cd8817d52f6cf2e414152"].into(),
+				// Treasury account
+				// C8KpmHUFT7HJbNLv74cXrtT1w9LF1W3WduN8nVGQUySSJTF
+				hex!["02c2cffef38fbf56b32d6a49eeeecc0e3345a1e0549cd8817d52f6cf2e414152"].into(),
 			)
 		},
 		// Bootnodes
@@ -408,6 +414,9 @@ pub fn local_config() -> Result<ChainSpec, String> {
 				// API admin account
 				// 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				// Treasury account
+				// 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+				get_account_id_from_seed::<sr25519::Public>("Alice"),
 			)
 		},
 		// Bootnodes
@@ -467,6 +476,9 @@ pub fn development_config() -> Result<ChainSpec, String> {
 				// API admin account
 				// 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				// Treasury account
+				// 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+				get_account_id_from_seed::<sr25519::Public>("Alice"),
 			)
 		},
 		// Bootnodes
@@ -498,6 +510,7 @@ fn genesis(
 	endowed_accounts: Vec<(AccountId, Balance)>,
 	appchain_config: (String, String, Balance, Balance),
 	api_admin_key: AccountId,
+	treasury_key: AccountId,
 ) -> GenesisConfig {
 	GenesisConfig {
 		system: SystemConfig { code: wasm_binary.to_vec() },
@@ -544,7 +557,10 @@ fn genesis(
 		genetic_analysts: GeneticAnalystsConfig {
 			genetic_analyst_verifier_key: api_admin_key.clone(),
 		},
-		genetic_analysis_orders: GeneticAnalysisOrdersConfig { escrow_key: api_admin_key.clone() },
+		genetic_analysis_orders: GeneticAnalysisOrdersConfig {
+			escrow_key: api_admin_key.clone(),
+			treasury_key: treasury_key.clone(),
+		},
 		service_request: ServiceRequestConfig { admin_key: api_admin_key.clone() },
 		user_profile: UserProfileConfig { admin_key: api_admin_key },
 	}

--- a/pallets/genetic-analysis-orders/benchmarking/src/lib.rs
+++ b/pallets/genetic-analysis-orders/benchmarking/src/lib.rs
@@ -15,7 +15,7 @@ use user_profile::Pallet as UserProfile;
 
 #[allow(unused)]
 use genetic_analysis_orders::Pallet as GeneticAnalysisOrders;
-use genetic_analysis_orders::{Config as GeneticAnalysisOrdersConfig, EscrowKey};
+use genetic_analysis_orders::{Config as GeneticAnalysisOrdersConfig, EscrowKey, TreasuryKey};
 
 #[allow(unused)]
 use genetic_analysis::Pallet as GeneticAnalysis;
@@ -407,6 +407,14 @@ benchmarks! {
 		let caller: T::AccountId = EscrowKey::<T>::get();
 		let caller2: T::AccountId = whitelisted_caller();
 	}: update_escrow_key(
+		RawOrigin::Signed(caller),
+		caller2
+	)
+
+	update_treasury_key {
+		let caller: T::AccountId = TreasuryKey::<T>::get();
+		let caller2: T::AccountId = whitelisted_caller();
+	}: update_treasury_key(
 		RawOrigin::Signed(caller),
 		caller2
 	)

--- a/pallets/genetic-analysis-orders/src/interface.rs
+++ b/pallets/genetic-analysis-orders/src/interface.rs
@@ -30,5 +30,9 @@ pub trait GeneticAnalysisOrderInterface<T: frame_system::Config> {
 		account_id: &T::AccountId,
 		escrow_key: &T::AccountId,
 	) -> Result<(), Self::Error>;
+	fn update_treasury_key(
+		account_id: &T::AccountId,
+		escrow_key: &T::AccountId,
+	) -> Result<(), Self::Error>;
 	fn is_pending_genetic_analysis_order_ids_by_seller_exist(account_id: &T::AccountId) -> bool;
 }

--- a/pallets/genetic-analysis-orders/src/lib.rs
+++ b/pallets/genetic-analysis-orders/src/lib.rs
@@ -448,7 +448,8 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			match <Self as GeneticAnalysisOrderInterface<T>>::update_treasury_key(&who, &account_id) {
+			match <Self as GeneticAnalysisOrderInterface<T>>::update_treasury_key(&who, &account_id)
+			{
 				Ok(_) => {
 					Self::deposit_event(Event::UpdateGeneticAnalysisOrderTreasuryKeySuccessful(
 						who.clone(),

--- a/pallets/genetic-analysis-orders/src/tests.rs
+++ b/pallets/genetic-analysis-orders/src/tests.rs
@@ -2113,3 +2113,25 @@ fn sudo_update_escrow_key_works() {
 		assert_eq!(GeneticAnalysisOrders::admin_key(), 1);
 	})
 }
+
+#[test]
+fn update_treasury_key_works() {
+	<ExternalityBuilder>::default().existential_deposit(1).build().execute_with(|| {
+		TreasuryKey::<Test>::put(2);
+
+		assert_eq!(GeneticAnalysisOrders::treasury_key(), 2);
+
+		assert_ok!(GeneticAnalysisOrders::update_treasury_key(Origin::signed(2), 1,));
+
+		assert_eq!(GeneticAnalysisOrders::treasury_key(), 1);
+	})
+}
+
+#[test]
+fn sudo_update_treasury_key_works() {
+	<ExternalityBuilder>::default().existential_deposit(1).build().execute_with(|| {
+		assert_ok!(GeneticAnalysisOrders::sudo_update_treasury_key(Origin::root(), 1));
+
+		assert_eq!(GeneticAnalysisOrders::treasury_key(), 1);
+	})
+}

--- a/pallets/genetic-analysis-orders/src/tests.rs
+++ b/pallets/genetic-analysis-orders/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{
 	mock::*, Error, EscrowKey, GeneticAnalysisOrder, GeneticAnalysisOrderStatus, PalletAccount,
+	TreasuryKey,
 };
 use frame_support::{
 	assert_noop, assert_ok,
@@ -503,6 +504,7 @@ fn fulfill_genetic_analysis_order_works() {
 		assert_ok!(Balances::set_balance(RawOrigin::Root.into(), 1, 10000, 0));
 
 		EscrowKey::<Test>::put(1);
+		TreasuryKey::<Test>::put(2);
 
 		assert_ok!(GeneticAnalysts::register_genetic_analyst(
 			Origin::signed(1),
@@ -603,6 +605,7 @@ fn fulfill_genetic_analysis_order_works() {
 		));
 
 		assert_eq!(Balances::free_balance(1), 9975);
+		assert_eq!(Balances::free_balance(2), 25);
 
 		assert_eq!(
 			GeneticAnalysisOrders::genetic_analysis_order_by_id(&_genetic_analysis_order_id),

--- a/pallets/genetic-analysis-orders/src/weights.rs
+++ b/pallets/genetic-analysis-orders/src/weights.rs
@@ -35,6 +35,7 @@ pub trait WeightInfo {
 	fn fulfill_genetic_analysis_order() -> Weight;
 	fn set_genetic_analysis_order_refunded() -> Weight;
 	fn update_escrow_key() -> Weight;
+	fn update_treasury_key() -> Weight;
 }
 
 /// Weights for genetic_analysis_orders using the Substrate node and recommended hardware.
@@ -108,6 +109,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	fn update_treasury_key() -> Weight {
+		23_012_000_u64
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -176,6 +182,11 @@ impl WeightInfo for () {
 	}
 	// Storage: GeneticAnalysisOrders EscrowKey (r:1 w:1)
 	fn update_escrow_key() -> Weight {
+		23_012_000_u64
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	fn update_treasury_key() -> Weight {
 		23_012_000_u64
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))


### PR DESCRIPTION
### JIRA LINK
- https://blocksphere2020.atlassian.net/browse/DBIO-2670
- https://blocksphere2020.atlassian.net/browse/DBIO-2728
- https://blocksphere2020.atlassian.net/browse/DBIO-2729
- https://blocksphere2020.atlassian.net/browse/DBIO-2730

### Changelog
- Added a treasury wallet to the `genetic-analysis-orders` pallet.
- Added new extrinsic to update treasury wallet keys.
- Send 5% of the `genetic-analysis-orders` pallet fees to the treasury wallet.