### PR TITLE
chore: bump version to 2.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "debio"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "debio-runtime"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "beefy-primitives",
  "certifications",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'debio'
-version = '2.2.5'
+version = '2.2.6'
 edition = '2021'
 license = 'AGPL-3.0'
 authors = ['DeBio Dev Team <debio_dev@blocksphere.id>']

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'debio-runtime'
-version = '2.2.5'
+version = '2.2.6'
 edition = '2021'
 license = 'AGPL-3.0'
 authors = ['DeBio Dev Team <debio_dev@blocksphere.id>']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -202,7 +202,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 2025,
+	spec_version: 2026,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
### JIRA LINK
- https://blocksphere2020.atlassian.net/browse/DBIO-ISSUE_NUMBER

### Changelog
- 