### PR TITLE
fix: validation and event when menstrual subscription paid

### DIFF
--- a/pallets/menstrual-subscription/src/functions.rs
+++ b/pallets/menstrual-subscription/src/functions.rs
@@ -112,9 +112,12 @@ impl<T: Config> Pallet<T> {
 			ExistenceRequirement::KeepAlive,
 		);
 
-		if result.is_ok() {
-			CurrencyOf::<T>::burn(amount);
+		if result.is_err() {
+			return Err(Error::<T>::InsufficientBalance)
 		}
+
+		CurrencyOf::<T>::burn(amount);
+		Self::deposit_event(Event::TotalSupplyDecreased(amount));
 
 		Ok(())
 	}

--- a/pallets/menstrual-subscription/src/lib.rs
+++ b/pallets/menstrual-subscription/src/lib.rs
@@ -167,6 +167,7 @@ pub mod pallet {
 		/// Update menstrual subscription admin key successful
 		/// parameters. [who]
 		UpdateMenstrualSubscriptionKeySuccessful(AccountKeyTypeOf<T>),
+		TotalSupplyDecreased(BalanceOf<T>),
 		MenstrualSubscriptionPriceAdded(MenstrualSubscriptionPriceOf<T>),
 	}
 


### PR DESCRIPTION
### JIRA LINK
- https://blocksphere2020.atlassian.net/browse/DBIO-3202

### Changelog
- add validation for menstrual subscription payment
- add burn event when menstrual subscription has been paid